### PR TITLE
eks-autoscaler and datadog exception problem fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 sandbox.auto.tfvars.json
 kubeconfig*
 .terraform

--- a/assumable_role_cluster_autoscaler.tf
+++ b/assumable_role_cluster_autoscaler.tf
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_role_policy_document" {
 
     condition {
       test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster_name}}"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${var.cluster_name}"
       values   = ["owned"]
     }
 

--- a/scripts/deploy_datadog_agent.sh
+++ b/scripts/deploy_datadog_agent.sh
@@ -1454,6 +1454,5 @@ helm upgrade --install datadog-agent datadog/datadog \
   --set datadog.tags=["cluster:$CLUSTER"] \
   --set dogstatsd.tags=["cluster:$CLUSTER"] \
   --set clusteragent.image.tag=$DATADOG_CLUSTER_AGENT_VERSION \
-  --set clusteragent.env=["DD_CLUSTER_CHECKS_ENABLED:true","DD_CLUSTER_NAME:$CLUSTER"] \
-  --set agent.image.tag=$DATADOG_AGENT_VERSION
+  --set agent.image.tag=$DATADOG_AGENT_VERSION \
   --set targetSystem=linux


### PR DESCRIPTION
The policy tag created by terraform is inconsistent with the autoscaler deployment tag
Modify the environment variable set when helm deploys the datadog agent, because it cannot pass the syntax check