### PR TITLE
Add cluster name to autoscaler module to ensure complete IAM definition

### DIFF
--- a/irsa-cluster-autoscaler.tf
+++ b/irsa-cluster-autoscaler.tf
@@ -11,4 +11,6 @@ module "cluster_autoscaler_irsa" {
       namespace_service_accounts = ["kube-system:cluster-autoscaler"]
     }
   }
+
+  cluster_autoscaler_cluster_names = [ var.cluster_name ]
 }


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Breaking changes

An update to the `iam-role-for-service-accounts-eks` module requires the cluster name to be passed to ensure a complete IAM definition is published, allowing the cluster autoscaler to make changes to the deployed Node group(s) for the cluster

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Fix to breaking change

**Test plan (required)**

Create any pod on the cluster that will force an autoscal, ensure an additional node is created.  For example, create a busybox pod with requests at 90% of an available node CPU to ensure an existing node does not have capacity.  Once the cluster autoscales to allow deployment, remove the test pod and ensure the node groups scales back down.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
